### PR TITLE
fix domain for plotting functions

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -77,6 +77,13 @@ class App extends React.Component {
           data={this.state.data}/>
 
         <VictoryScatter
+          style={style}
+          width={500}
+          height={500}
+          y={(x) => Math.sin(2 * Math.PI * x)}
+          sample={25}/>
+
+        <VictoryScatter
           width={500}
           height={500}
           padding={50}
@@ -90,6 +97,8 @@ class App extends React.Component {
             style,
             {data: {fill: "blue", opacity: 0.7}}
           )}
+          width={500}
+          height={500}
           bubbleProperty="z"
           maxBubbleSize={20}
           showLabels={false}

--- a/src/components/victory-scatter.jsx
+++ b/src/components/victory-scatter.jsx
@@ -202,6 +202,7 @@ export default class VictoryScatter extends React.Component {
       x: this.getRange(props, "x"),
       y: this.getRange(props, "y")
     };
+    this.data = this.getData(props);
     this.domain = {
       x: this.getDomain(props, "x"),
       y: this.getDomain(props, "y")
@@ -210,7 +211,6 @@ export default class VictoryScatter extends React.Component {
       x: this.getScale(props, "x"),
       y: this.getScale(props, "y")
     };
-    this.data = this.getData(props);
   }
 
   getStyles(props) {
@@ -254,13 +254,12 @@ export default class VictoryScatter extends React.Component {
   getDomain(props, axis) {
     if (props.domain) {
       return props.domain[axis] || props.domain;
-    } else if (props.data) {
+    } else {
       return [
-        _.min(_.pluck(props.data, axis)),
-        _.max(_.pluck(props.data, axis))
+        _.min(_.pluck(this.data, axis)),
+        _.max(_.pluck(this.data, axis))
       ];
     }
-    return props.scale[axis] ? props.scale[axis].domain() : props.scale.domain();
   }
 
   getData(props) {
@@ -284,7 +283,11 @@ export default class VictoryScatter extends React.Component {
     }
     // if x is not given in props, create an array of values evenly
     // spaced across the x domain
-    const domain = this.domain.x;
+    const domainFromProps = props.domain && props.domain.x || props.domain;
+    const domainFromScale = props.scale && props.scale.x ?
+      props.scale.x.domain() : props.scale.domain();
+    const domain = domainFromProps || domainFromScale;
+
     const samples = _.isArray(props.y) ? props.y.length : props.samples;
     const step = _.max(domain) / samples;
     // return an array of x values spaced across the domain,


### PR DESCRIPTION
cc/ @exogen

I noticed that when plotting functions that result in negative values, the domain was not being set properly. Changes in this PR:

`this.data` is calculated before domain
`returnOrGenerateX` determines a default domain from `props.domain` or `props.scale`
`this.domain` is calculated based on `this.data` instead of `props.data`
